### PR TITLE
Locate Kafka Dependencies on Windows

### DIFF
--- a/buildconfig/CMake/FindLibRDKafka.cmake
+++ b/buildconfig/CMake/FindLibRDKafka.cmake
@@ -20,22 +20,53 @@
 find_path(LibRDKafka_ROOT_DIR
         NAMES include/librdkafka/rdkafkacpp.h
         PATHS /usr/local
-        )
-
-find_library(LibRDKafka_LIBRARIES
-        NAMES rdkafka++
-        HINTS ${LibRDKafka_ROOT_DIR}/lib
-        )
-
-find_library(LibRDKafka_C_LIBRARIES
-        NAMES rdkafka
-        HINTS ${LibRDKafka_ROOT_DIR}/lib
-        )
-
+        )   
 find_path(LibRDKafka_INCLUDE_DIR
         NAMES librdkafka/rdkafkacpp.h
         HINTS ${LibRDKafka_ROOT_DIR}/include
         )
+find_library(LibRDKafka
+        NAMES rdkafka++ librdkafkacpp
+        HINTS ${LibRDKafka_ROOT_DIR}/lib
+        )
+find_library(LibRDKafka_DEBUG
+        NAMES librdkafkacpp_D
+        HINTS ${LibRDKafka_ROOT_DIR}/lib
+        )
+find_library(LibRDKafka_C
+        NAMES rdkafka librdkafka
+        HINTS ${LibRDKafka_ROOT_DIR}/lib
+        )
+find_library(LibRDKafka_C_DEBUG
+        NAMES librdkafka_D
+        HINTS ${LIBRDKafka_ROOT_DIR}/lib
+        )
+        
+if( LibRDKafka_DEBUG )
+
+set( LibRDKafka_LIBRARIES optimized ${LibRDKafka}
+                          debug ${LibRDKafka_DEBUG}
+)
+
+else ()
+
+set( LibRDKafka_LIBRARIES ${LibRDKafka}
+)
+
+endif ()
+
+if( LibRDKafka_C_DEBUG )
+
+set( LibRDKafka_C_LIBRARIES optimized ${LibRDKafka_C}
+                            debug ${LibRDKafka_C_DEBUG}
+)
+
+else ()
+
+set( LibRDKafka_C_LIBRARIES ${LibRDKafka_C} 
+)
+
+endif ()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibRDKafka DEFAULT_MSG

--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -78,6 +78,8 @@ set ( MISC_CORE_DIST_DLLS
     libeay32.dll
     libNeXus-0.dll
     libNeXusCPP-0.dll
+    librdkafka.dll
+    librdkafkacpp.dll
     ssleay32.dll
     szip.dll
     tbb.dll


### PR DESCRIPTION
**To test:**

* Clone https://github.com/ScreamingUdder/mantid
* Checkout out the kafka live listener branch `git checkout matthew-jones/isis_kafka_listener`
* Modify `PathToMantidCodebase\buildconfig\CMake\Bootstrap.cmake` and replace: 
  ```  
  set ( THIRD_PARTY_GIT_SHA1 d3d733e772a57b18b663f3b79439a068bb00a71c )
  ``` 
  with: 
  ```  
  set ( THIRD_PARTY_GIT_SHA1 ac57236e560ef78a60cdec32503c26cf013cdf08)
  ```
  Which is the most recent SHA1 for [this](https://github.com/mantidproject/thirdparty-msvc2015/pull/15) PR. (*This might change just double check below by clicking on the most recent commit*).
* Run cmake on the code base which should be able to find librdkafka (Verify this by checking the output).
  ```
  Found LibRDKafka: optimized;C:/mantid_dev2/external/src/ThirdParty/lib/librdkafkacpp.lib;debug;C:/mantid_dev2/external/src/ThirdParty/lib/librdkafkacpp_D.lib
  ```
* Enable CPack and run cmake again.
* Build the PACKAGES build target and ensure the windows installer contains the librdkafka libraries.
Fixes #3 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
