### PR TITLE
Fix failing tests in LiveData due to gtest changes upstream

### DIFF
--- a/Framework/LiveData/test/CMakeLists.txt
+++ b/Framework/LiveData/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if ( CXXTEST_FOUND )
-  include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} )
+  include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR} )
 
   include_directories ( ../../TestHelpers/inc )
   # This variable is used within the cxxtest_add_test macro to build this helper class into the test executable.


### PR DESCRIPTION
Include gmock in the CMakeLists file for LiveData tests. This required since upstream changed to include gtest as an external project.
