### PR TITLE
Kafka buffer limitation

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISKafkaEventStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISKafkaEventStreamDecoder.h
@@ -77,6 +77,7 @@ private:
   void captureImplExcept();
 
   void initLocalCaches();
+  size_t getBufferMemorySizeBytes() noexcept;
   DataObjects::EventWorkspace_sptr createBufferWorkspace(const size_t nspectra,
                                                          const int32_t *spec,
                                                          const int32_t *udet,
@@ -133,6 +134,8 @@ private:
   bool m_runStatusSeen;
 
   std::atomic<bool> m_extractedEndRunData;
+
+  const size_t MAX_BUFFER_SIZE;
 };
 
 } // namespace LiveData

--- a/Framework/LiveData/src/ISIS/ISISKafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/ISIS/ISISKafkaEventStreamDecoder.cpp
@@ -120,11 +120,11 @@ using Kernel::DateAndTime;
 ISISKafkaEventStreamDecoder::ISISKafkaEventStreamDecoder(
     std::shared_ptr<IKafkaBroker> broker, const std::string &eventTopic,
     const std::string &runInfoTopic, const std::string &spDetTopic)
-    : m_broker(broker), m_eventTopic(eventTopic),
-      m_runInfoTopic(runInfoTopic), m_spDetTopic(spDetTopic),
-      m_interrupt(false), m_localEvents(), m_specToIdx(), m_runStart(),
-      m_runNumber(-1), m_thread(), m_capturing(false), m_exception(),
-      m_extractWaiting(false) {}
+    : m_broker(broker), m_eventTopic(eventTopic), m_runInfoTopic(runInfoTopic),
+      m_spDetTopic(spDetTopic), m_interrupt(false), m_localEvents(),
+      m_specToIdx(), m_runStart(), m_runNumber(-1), m_thread(),
+      m_capturing(false), m_exception(), m_extractWaiting(false),
+      MAX_BUFFER_SIZE(1073741824) {}
 
 /**
  * Destructor.
@@ -285,6 +285,8 @@ void ISISKafkaEventStreamDecoder::captureImplExcept() {
   m_extractedEndRunData = true;
   std::string buffer;
   while (!m_interrupt) {
+    if (getBufferMemorySizeBytes() > MAX_BUFFER_SIZE)
+      continue;
     // Pull in events
     m_eventStream->consumeMessage(&buffer);
     // No events, wait for some to come along...
@@ -436,6 +438,17 @@ void ISISKafkaEventStreamDecoder::initLocalCaches() {
     // A clone should be cheap here as there are no events yet
     m_localEvents[i] = eventBuffer->clone();
   }
+}
+
+size_t ISISKafkaEventStreamDecoder::getBufferMemorySizeBytes() noexcept {
+  size_t size = 0;
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  for (auto &wksp : m_localEvents) {
+    size += wksp->getMemorySize();
+  }
+
+  return size;
 }
 
 /**

--- a/Framework/LiveData/src/ISIS/ISISKafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/ISIS/ISISKafkaEventStreamDecoder.cpp
@@ -285,8 +285,10 @@ void ISISKafkaEventStreamDecoder::captureImplExcept() {
   m_extractedEndRunData = true;
   std::string buffer;
   while (!m_interrupt) {
-    if (getBufferMemorySizeBytes() > MAX_BUFFER_SIZE)
+    if (getBufferMemorySizeBytes() > MAX_BUFFER_SIZE) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
       continue;
+    }
     // Pull in events
     m_eventStream->consumeMessage(&buffer);
     // No events, wait for some to come along...

--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -1,12 +1,12 @@
 #include "MantidLiveData/LoadLiveData.h"
-#include "MantidLiveData/Exception.h"
-#include "MantidKernel/WriteLock.h"
-#include "MantidKernel/ReadLock.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/CPUTimer.h"
+#include "MantidKernel/ReadLock.h"
+#include "MantidKernel/WriteLock.h"
+#include "MantidLiveData/Exception.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -101,8 +101,8 @@ LoadLiveData::runProcessing(Mantid::API::Workspace_sptr inputWS,
       for (auto prop : proplist) {
         if ((prop->direction() == 0) && (!inputPropertyWorkspaceFound)) {
           if (boost::ends_with(prop->type(), "Workspace")) {
-            g_log.information() << "Using " << prop->name()
-                                << " as the input property.\n";
+            g_log.information()
+                << "Using " << prop->name() << " as the input property.\n";
             alg->setPropertyValue(prop->name(), inputName);
             inputPropertyWorkspaceFound = true;
           }
@@ -366,7 +366,8 @@ Workspace_sptr LoadLiveData::appendMatrixWSChunk(Workspace_sptr accumWS,
  * @param ws :: any Workspace. Does nothing if not EventWorkspace.
  */
 void LoadLiveData::doSortEvents(Mantid::API::Workspace_sptr ws) {
-  EventWorkspace_sptr eventWS = boost::dynamic_pointer_cast<EventWorkspace>(ws);
+  /*EventWorkspace_sptr eventWS =
+  boost::dynamic_pointer_cast<EventWorkspace>(ws);
   if (!eventWS)
     return;
   CPUTimer tim;
@@ -374,7 +375,9 @@ void LoadLiveData::doSortEvents(Mantid::API::Workspace_sptr ws) {
   alg->setProperty("InputWorkspace", eventWS);
   alg->setPropertyValue("SortBy", "X Value");
   alg->executeAsChildAlg();
-  g_log.debug() << tim << " to perform SortEvents on " << ws->getName() << '\n';
+  g_log.debug() << tim << " to perform SortEvents on " << ws->getName() <<
+  '\n';*/
+  return;
 }
 
 //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Kafka consumption is halted if the Mantid Buffer exceeds 1GB.

**To test:**

Code review and ensure the execution of `MonitorLiveData`is not affected.

Fixes #24 .

<!-- RELEASE NOTES
Either edit the file in docs/source/release/... and it will be in your pull request or state
*Does not need to be in the release notes.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://www.mantidproject.org/Individual_Ticket_Testing)):

##### Code Review #####

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](http://www.mantidproject.org/Coding_Standards)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit/system tests in place? Are the unit tests small and test the a class in isolation?
- [ ] If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- [ ] Do changes function as described? Add comments below that describe the tests performed?
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has the relevant documentation been added/updated?
- [ ] Is user-facing documentation written in a user-friendly manner?
- [ ] Has developer documentation been updated if required?

- Does everything look good? Comment with the ship it emoji but don't merge. A member of `@mantidproject/gatekeepers` will take care of it.
