### PR TITLE
Update release notes for Kafka listener

### DIFF
--- a/docs/source/release/v3.10.0/framework.rst
+++ b/docs/source/release/v3.10.0/framework.rst
@@ -51,7 +51,7 @@ Improved
 LiveData
 --------
 
-- A new live listener for event data at ISIS, `ISISKafkaEventListener`, has been added. This is currently being tested on a limited number of beamlines.
+- A new live listener for event data, `KafkaEventListener`, has been added. This is in development for the ESS and ISIS. It is only available on IBEX instruments at ISIS.
 
 Python
 ------


### PR DESCRIPTION
Make it clear in the release notes that the Kafka listener is only available for IBEX instruments at ISIS.